### PR TITLE
fix: docker build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,10 @@ WORKDIR /src
 
 # for east asia user, you can uncomment the following lines
 # to speed up the installation of the dependencies
-RUN printf "sass_binary_site=https://npm.taobao.org/mirrors/node-sass\nphantomjs_cdnurl=https://npm.taobao.org/mirrors/phantomjs\nelectron_mirror=https://npm.taobao.org/mirrors/electron\nregistry=https://registry.npm.taobao.org" > ~/.npmrc
+# RUN printf "sass_binary_site=https://npm.taobao.org/mirrors/node-sass\nphantomjs_cdnurl=https://npm.taobao.org/mirrors/phantomjs\nelectron_mirror=https://npm.taobao.org/mirrors/electron\nregistry=https://registry.npm.taobao.org" > ~/.npmrc
 
 COPY package.json package.json
-# RUN npm install
+RUN npm install
 
 COPY . .
 RUN npm run build


### PR DESCRIPTION
root cause:
  the process of installation of the dependencies is commented

solution:
  uncomment the line 17 in Dockerfile
  comment the line 14 since it should be commented by default